### PR TITLE
Add idempotent spel, token wrappers for http type idempotent 

### DIFF
--- a/idm-sdk/idm-core/src/main/java/com/cloudnative/idm/aspect/wrapper/IdempotentSpelWrapper.java
+++ b/idm-sdk/idm-core/src/main/java/com/cloudnative/idm/aspect/wrapper/IdempotentSpelWrapper.java
@@ -1,0 +1,39 @@
+package com.cloudnative.idm.aspect.wrapper;
+
+import com.cloudnative.idm.annotation.Idempotent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.aspectj.lang.ProceedingJoinPoint;
+
+/**
+ * Wrapper for SpEL-based idempotency
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+public class IdempotentSpelWrapper {
+    /**
+     * Idempotent annotation
+     */
+    private Idempotent idempotent;
+
+    /**
+     * AOP join point
+     */
+    private ProceedingJoinPoint joinPoint;
+
+    /**
+     * Computed lock key from SpEL
+     */
+    private String lockKey;
+
+    /**
+     * Original SpEL expression
+     */
+    private String spelKey;
+}

--- a/idm-sdk/idm-core/src/main/java/com/cloudnative/idm/aspect/wrapper/IdempotentTokenWrapper.java
+++ b/idm-sdk/idm-core/src/main/java/com/cloudnative/idm/aspect/wrapper/IdempotentTokenWrapper.java
@@ -1,0 +1,37 @@
+package com.cloudnative.idm.aspect.wrapper;
+
+import com.cloudnative.idm.annotation.Idempotent;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.aspectj.lang.ProceedingJoinPoint;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Accessors(chain = true)
+public class IdempotentTokenWrapper {
+    /**
+     * Idempotent annotation metadata
+     */
+    private Idempotent idempotent;
+
+    /**
+     * Join point for AOP interception
+     */
+    private ProceedingJoinPoint joinPoint;
+
+    /**
+     * Lock key built using a token (e.g., from header or body).
+     * @see com.cloudnative.idm.enums.IdempotentTypeEnum#TOKEN
+     */
+    private String lockKey;
+
+    /**
+     * Raw token string extracted from request
+     */
+    private String requestToken;
+}


### PR DESCRIPTION
In this branch, we added a new content wrapper system for the @Idempotent annotation.

Each annotated method can pass parameters (e.g., method args or SpEL like #order.id).
Different wrappers handle different input types, extract key parts, and convert them into wrapper instances.

These instances are then used as hash keys for the idempotency cache.

This makes key generation more flexible and supports custom logic per input type.